### PR TITLE
AOS-95 Hide RandomIngesterRestController. Delete unused variables.

### DIFF
--- a/src/main/java/no/difi/statistics/api/IngestRestController.java
+++ b/src/main/java/no/difi/statistics/api/IngestRestController.java
@@ -6,13 +6,10 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import no.difi.statistics.IngestService;
-import no.difi.statistics.PropertyLogger;
 import no.difi.statistics.model.MeasurementDistance;
 import no.difi.statistics.model.TimeSeriesDefinition;
 import no.difi.statistics.model.TimeSeriesPoint;
 import no.difi.statistics.validation.ValidOrgno;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -31,13 +28,6 @@ import java.util.Map;
 @Tag(name = "Statistikk-inndata-api", description = "Legg data inn i statistikk-databasen")
 @RestController
 public class IngestRestController {
-    private static final Logger logger = LoggerFactory.getLogger(PropertyLogger.class);
-
-    private static final String DIGDIR_ORGNR = "991825827";
-    private static final String OWNER_EXPLANATION = "eigar av tidsserien i form av eit organisasjonsnummer";
-    private static final String SERIES_NAME_EXPLANATION = "tidsserier finnes ved oppslag i /meta";
-    private static final String DISTANCE_EXPLANATION = "tidsserien sin måleavstand";
-
     private IngestService ingestService;
 
     public IngestRestController(IngestService ingestService) {
@@ -68,7 +58,7 @@ public class IngestRestController {
             @PathVariable String owner, @ValidOrgno
             @Parameter(name = "seriesName", example = "idporten-innlogging", required = true, description = "namn på tidsserie")
             @PathVariable String seriesName,
-            @Parameter(name = DISTANCE_EXPLANATION, required = true)
+            @Parameter(name = "distance", required = true, description = "tidsserien sin måleavstand")
             @PathVariable MeasurementDistance distance,
             @RequestBody List<TimeSeriesPoint> dataPoints
     ) {

--- a/src/main/java/no/difi/statistics/poc/RandomIngesterRestController.java
+++ b/src/main/java/no/difi/statistics/poc/RandomIngesterRestController.java
@@ -1,5 +1,6 @@
 package no.difi.statistics.poc;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import no.difi.statistics.IngestService;
 import no.difi.statistics.model.MeasurementDistance;
 import no.difi.statistics.model.TimeSeriesDefinition;
@@ -25,6 +26,7 @@ public class RandomIngesterRestController {
         this.service = service;
     }
 
+    @Hidden
     @RequestMapping(
             method = RequestMethod.POST,
             value = "{owner}/{seriesName}/{distance}",


### PR DESCRIPTION
Skjuler RandomIngestRestController-endepunktet da det tilføjer fra- og til-felter i POST i swagger i IngestRestController. Antageligvis pga. migrering til nyere swagger-version, som omfavner mere.